### PR TITLE
VN-524 add hanlding for network interuption cases

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "editor.renderWhitespace": "all"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-  "editor.renderWhitespace": "all"
-}

--- a/index.js
+++ b/index.js
@@ -190,8 +190,14 @@ module.exports.download = (win, url, options) => new Promise((resolve, reject) =
   if (!sessionListenerMap.get(session)) {
     sessionListenerMap.set(session, true);
     session.on('will-download', registerListener(session));
-    win.on('close', () => unregisterListener(session));
+		win.on('close', () => unregisterListener(session));
   }
 
 	win.webContents.downloadURL(url);
+});
+
+module.exports.cleanUp = (win) => new Promise((resolve, reject) => {
+	if (win) {
+		win.setProgressBar(-1);
+	}
 });

--- a/index.js
+++ b/index.js
@@ -97,7 +97,8 @@ function registerListener(session) {
 				// No download progress, the download maybe passively interupted (network issue)
 				// Electron does not raised interupted state for this case at the moment, so we handle ourself
         if (handlers.noProgress === CONFIG.NO_PROGRESS_THRESHOLD) {
-          item.removeAllListeners();
+					item.removeAllListeners();
+					win.setProgressBar(-1);
           return reject(new Error(`Failed to download for ${key}`));
         }
 
@@ -145,6 +146,7 @@ function registerListener(session) {
 				electron.dialog.showErrorBox(errorTitle, message);
 				reject(new Error(message));
 			} else if (state === 'cancelled') {
+				win.setProgressBar(-1);
 				reject(new Error('The download has been cancelled'));
 			} else if (state === 'completed') {
 				if (process.platform === 'darwin') {
@@ -194,10 +196,4 @@ module.exports.download = (win, url, options) => new Promise((resolve, reject) =
   }
 
 	win.webContents.downloadURL(url);
-});
-
-module.exports.cleanUp = (win) => new Promise((resolve, reject) => {
-	if (win) {
-		win.setProgressBar(-1);
-	}
 });

--- a/index.js
+++ b/index.js
@@ -174,9 +174,10 @@ function unregisterListener (session) {
 }
 
 function _resetStats (win) {
-  if (!win.isDestroyed()) {
+  if (win && !win.isDestroyed()) {
     win.setProgressBar(-1);
-  }
+	}
+
   receivedBytes = 0;
   completedBytes = 0;
   totalBytes = 0;
@@ -200,7 +201,7 @@ module.exports.download = (win, url, options) => new Promise((resolve, reject) =
   // Only need to register listener for new window/session
   if (!sessionListenerMap.get(session)) {
     sessionListenerMap.set(session, true);
-    session.on('will-download', registerListener(session));
+		session.on('will-download', () => registerListener(session));
     win.on('close', () => unregisterListener(session));
   }
 

--- a/index.js
+++ b/index.js
@@ -9,17 +9,18 @@ const _ = require('lodash');
 const {app, shell} = electron;
 
 const CONFIG = {
-	NO_PROGRESS_THRESHOLD: 20
+  NO_PROGRESS_THRESHOLD: 20,
+  DOWNLOAD_MAX_RETRY: 3
 };
 
 function getFilenameFromMime(name, mime) {
-	const exts = extName.mime(mime);
+  const exts = extName.mime(mime);
 
-	if (exts.length !== 1) {
-		return name;
-	}
+  if (exts.length !== 1) {
+    return name;
+  }
 
-	return `${name}.${exts[0].ext}`;
+  return `${name}.${exts[0].ext}`;
 }
 
 const sessionListenerMap = new Map();
@@ -30,56 +31,57 @@ let completedBytes = 0;
 let totalBytes = 0;
 const activeDownloadItems = () => downloadItems.size;
 const progressDownloadItems = function (item) {
-	if (item) {
-		return item.getReceivedBytes() / item.getTotalBytes();
-	}
-	return receivedBytes / totalBytes;
+  if (item) {
+    return item.getReceivedBytes() / item.getTotalBytes();
+  }
+  return receivedBytes / totalBytes;
 };
 
 function registerListener(session) {
-	const listener = (e, item, webContents) => {
-		const urlChains = item.getURLChain();
-		const originUrl = _.first(urlChains);
-		const key = decodeURIComponent(originUrl);
-		const defaultHanlder = {
-			options: {},
-			resolve: () => { },
-			reject: () => { }
-		};
+  const listener = (e, item, webContents) => {
+    const urlChains = item.getURLChain();
+    const originUrl = _.first(urlChains);
+    const key = decodeURIComponent(originUrl);
+    const defaultHanlder = {
+      options: {},
+      resolve: () => { },
+      reject: () => { }
+    };
 
-    var handlers = handlerMap.get(key);
-    const {options, resolve, reject} = handlers || defaultHanlder;
+    var handlers = handlerMap.get(key) || defaultHanlder;
+    const {options, resolve, reject} = handlers;
 
-		downloadItems.add(item);
-		totalBytes += item.getTotalBytes();
+    downloadItems.add(item);
+    totalBytes += item.getTotalBytes();
 
-		let hostWebContents = webContents;
-		if (webContents.getType() === 'webview') {
-			({hostWebContents} = webContents);
-		}
-		const win = electron.BrowserWindow.fromWebContents(hostWebContents);
+    let hostWebContents = webContents;
+    if (webContents.getType() === 'webview') {
+      ({hostWebContents} = webContents);
+    }
+    const win = electron.BrowserWindow.fromWebContents(hostWebContents);
 
-		const dir = options.directory || app.getPath('downloads');
-		let filePath;
-		if (options.filename) {
-			filePath = path.join(dir, options.filename);
-		} else {
-			const filename = item.getFilename();
-			const name = path.extname(filename) ? filename : getFilenameFromMime(filename, item.getMimeType());
+    const dir = options.directory || app.getPath('downloads');
+    let filePath;
+    if (options.filename) {
+      filePath = path.join(dir, options.filename);
+    } else {
+      const filename = item.getFilename();
+      const name = path.extname(filename) ? filename : getFilenameFromMime(filename, item.getMimeType());
 
-			filePath = unusedFilename.sync(path.join(dir, name));
-		}
+      filePath = unusedFilename.sync(path.join(dir, name));
+    }
 
-		const errorMessage = options.errorMessage || 'The download of {filename} was interrupted';
-		const errorTitle = options.errorTitle || 'Download Error';
+    const errorMessage = options.errorMessage || 'The download of {filename} was interrupted';
+    const errorTitle = options.errorTitle || 'Download Error';
 
-		if (!options.saveAs) {
-			item.setSavePath(filePath);
-		}
+    if (!options.saveAs) {
+      item.setSavePath(filePath);
+    }
 
-		item.on('updated', (e, state) => {
-      if (handlers.retryCount === 3) {
+    item.on('updated', (e, state) => {
+      if (handlers.retryCount >= CONFIG.DOWNLOAD_MAX_RETRY) {
         item.removeAllListeners();
+        win.setProgressBar(-1);
         return reject(new Error(`Failed to start download for ${key}`));
       }
 
@@ -87,18 +89,18 @@ function registerListener(session) {
         // This may a flash network interuption, we can retry a few times
         setTimeout(() => {
           handlers.retryCount++;
-					item.resume();
-				}, 5000);
-				return;
+          item.resume();
+        }, 5000);
+        return;
       }
 
       var updateProgress = progressDownloadItems(item);
       if (updateProgress === handlers.progress) {
-				// No download progress, the download maybe passively interupted (network issue)
-				// Electron does not raised interupted state for this case at the moment, so we handle ourself
+        // No download progress, the download maybe passively interupted (network issue)
+        // Electron does not raised interupted state for this case at the moment, so we handle ourself
         if (handlers.noProgress === CONFIG.NO_PROGRESS_THRESHOLD) {
-					item.removeAllListeners();
-					win.setProgressBar(-1);
+          item.removeAllListeners();
+          win.setProgressBar(-1);
           return reject(new Error(`Failed to download for ${key}`));
         }
 
@@ -107,82 +109,82 @@ function registerListener(session) {
         handlers.progress = updateProgress;
         handlers.noProgress = 0;
       }
-			receivedBytes = [...downloadItems].reduce((receivedBytes, item) => {
-				receivedBytes += item.getReceivedBytes();
-				return receivedBytes;
-			}, completedBytes);
+      receivedBytes = [...downloadItems].reduce((receivedBytes, item) => {
+        receivedBytes += item.getReceivedBytes();
+        return receivedBytes;
+      }, completedBytes);
 
-			if (['darwin', 'linux'].includes(process.platform)) {
-				app.setBadgeCount(activeDownloadItems());
-			}
+      if (['darwin', 'linux'].includes(process.platform)) {
+        app.setBadgeCount(activeDownloadItems());
+      }
 
-			if (!win.isDestroyed()) {
-				win.setProgressBar(progressDownloadItems());
-			}
+      if (!win.isDestroyed()) {
+        win.setProgressBar(progressDownloadItems());
+      }
 
-			if (typeof options.onProgress === 'function') {
-				options.onProgress(progressDownloadItems(item));
-			}
-		});
+      if (typeof options.onProgress === 'function') {
+        options.onProgress(progressDownloadItems(item));
+      }
+    });
 
-		item.once('done', (e, state) => {
-			completedBytes += item.getTotalBytes();
+    item.once('done', (e, state) => {
+      completedBytes += item.getTotalBytes();
       item.removeAllListeners();
-			downloadItems.delete(item);
+      downloadItems.delete(item);
 
-			if (['darwin', 'linux'].includes(process.platform)) {
-				app.setBadgeCount(activeDownloadItems());
-			}
+      if (['darwin', 'linux'].includes(process.platform)) {
+        app.setBadgeCount(activeDownloadItems());
+      }
 
-			if (!win.isDestroyed() && !activeDownloadItems()) {
-				win.setProgressBar(-1);
-				receivedBytes = 0;
-				completedBytes = 0;
-				totalBytes = 0;
-			}
+      if (!win.isDestroyed() && !activeDownloadItems()) {
+        win.setProgressBar(-1);
+        receivedBytes = 0;
+        completedBytes = 0;
+        totalBytes = 0;
+      }
 
-			if (state === 'interrupted') {
-				const message = pupa(errorMessage, {filename: item.getFilename()});
-				electron.dialog.showErrorBox(errorTitle, message);
-				reject(new Error(message));
-			} else if (state === 'cancelled') {
-				win.setProgressBar(-1);
-				reject(new Error('The download has been cancelled'));
-			} else if (state === 'completed') {
-				if (process.platform === 'darwin') {
-					app.dock.downloadFinished(filePath);
-				}
+      if (state === 'interrupted') {
+        const message = pupa(errorMessage, {filename: item.getFilename()});
+        electron.dialog.showErrorBox(errorTitle, message);
+        reject(new Error(message));
+      } else if (state === 'cancelled') {
+        win.setProgressBar(-1);
+        reject(new Error('The download has been cancelled'));
+      } else if (state === 'completed') {
+        if (process.platform === 'darwin') {
+          app.dock.downloadFinished(filePath);
+        }
 
-				if (options.openFolderWhenDone) {
-					shell.showItemInFolder(filePath);
-				}
+        if (options.openFolderWhenDone) {
+          shell.showItemInFolder(filePath);
+        }
 
-				resolve(item);
-			}
-			if (handlerMap.has(key)) {
-				handlerMap.delete(key);
-			}
-		});
-	};
+        resolve(item);
+      }
+      if (handlerMap.has(key)) {
+        handlerMap.delete(key);
+      }
+    });
+  };
 
   return listener;
 }
 
 function unregisterListener (session) {
-	if (sessionListenerMap.has(session)) {
-		sessionListenerMap.delete(session);
-	}
+  if (sessionListenerMap.has(session)) {
+    sessionListenerMap.delete(session);
+  }
 }
 
 module.exports = (options = {}) => {
-	app.on('session-created', session => {
-		registerListener(session, options);
-		app.on('close', () => unregisterListener(session));
-	});
+  app.on('session-created', session => {
+    registerListener(session, options);
+    app.on('close', () => unregisterListener(session));
+  });
 };
 
 module.exports.download = (win, url, options) => new Promise((resolve, reject) => {
-	options = Object.assign({}, options, {unregisterWhenDone: true});
+  options = Object.assign({}, options, {unregisterWhenDone: true});
 
   const key = decodeURIComponent(url);
   handlerMap.set(key, {options, resolve, reject, progress: 0, retryCount: 0, noProgress: 0});
@@ -192,8 +194,8 @@ module.exports.download = (win, url, options) => new Promise((resolve, reject) =
   if (!sessionListenerMap.get(session)) {
     sessionListenerMap.set(session, true);
     session.on('will-download', registerListener(session));
-		win.on('close', () => unregisterListener(session));
+    win.on('close', () => unregisterListener(session));
   }
 
-	win.webContents.downloadURL(url);
+  win.webContents.downloadURL(url);
 });

--- a/index.js
+++ b/index.js
@@ -136,7 +136,9 @@ function registerListener(session) {
         app.setBadgeCount(activeDownloadItems());
       }
 
-      _resetStats(win);
+      if (!activeDownloadItems()) {
+        _resetStats(win);
+      }
 
       if (state === 'interrupted') {
         const message = pupa(errorMessage, {filename: item.getFilename()});
@@ -174,10 +176,11 @@ function unregisterListener (session) {
 function _resetStats (win) {
   if (!win.isDestroyed()) {
     win.setProgressBar(-1);
-    receivedBytes = 0;
-    completedBytes = 0;
-    totalBytes = 0;
   }
+  receivedBytes = 0;
+  completedBytes = 0;
+  totalBytes = 0;
+  downloadItems.clear();
 }
 
 module.exports = (options = {}) => {


### PR DESCRIPTION
There're 2 cases covered on this change:
1. Network is interupted before the invoke of  `webContents.downloadURL()`, downloadItem does not raise `close` event but `updated` event with `state=interupted`. 
 - Current behavior: it hangs there forever event the network is back
 - Solution: we add retry for 3 times before force closing the download ourself.

2. The download is in progress and got network interuption.
 - Current behavior:
    - If network is back: the download is resume and can finish it
    - if the network is never back, it hangs there forever
 - Solution: we add a tracking of unchanged progress for awhile and force to close the downlaod ourself.
